### PR TITLE
Fixed: full usage of custom "ResourceLock" model class

### DIFF
--- a/src/Models/Concerns/HasLocks.php
+++ b/src/Models/Concerns/HasLocks.php
@@ -27,7 +27,8 @@ trait HasLocks
     public function lock(): bool
     {
         if (! $this->isLocked()) {
-            $resourceLock = new ResourceLock;
+            $resourceLockModel = config('resource-lock.models.ResourceLock', ResourceLock::class);
+            $resourceLock = new $resourceLockModel;
             $resourceLock->user_id = auth()->user()->id;
             $this->resourceLock()->save($resourceLock);
 


### PR DESCRIPTION
Fixed a bug where the trait wasn't use the custom `ResourceLock` model class if configured.