### PR TITLE
Extending translatable labels and adding plural label support

### DIFF
--- a/config/resource-lock.php
+++ b/config/resource-lock.php
@@ -63,6 +63,7 @@ return [
     'manager' => [
         'navigation_badge' => false,
         'navigation_label' => 'Resource Lock Manager',
+        'plural_label' => 'Resource Locks',
         'navigation_group' => 'Settings',
         'navigation_sort' => 1,
         'limited_access' => false,

--- a/src/Resources/ResourceLockResource.php
+++ b/src/Resources/ResourceLockResource.php
@@ -17,7 +17,12 @@ class ResourceLockResource extends Resource
 
     public static function getModel(): string
     {
-        return config('resource-lock.models.ResourceLock', ResourceLock::class);
+        return __(config('resource-lock.models.ResourceLock', ResourceLock::class));
+    }
+
+    public static function getPluralLabel(): string
+    {
+        return __(config('resource-lock.manager.plural_label', 'Resource Locks'));
     }
     
     public static function form(Form $form): Form
@@ -32,13 +37,13 @@ class ResourceLockResource extends Resource
     {
         return $table
             ->columns([
-                TextColumn::make('id')->label('Lock ID'),
-                TextColumn::make('user.id')->label('User ID'),
-                TextColumn::make('lockable.id')->label('Lockable ID'),
-                TextColumn::make('lockable_type'),
-                TextColumn::make('created_at'),
-                TextColumn::make('updated_at'),
-                TextColumn::make('updated_at')->label('Expired')
+                TextColumn::make('id')->label(__('Lock ID')),
+                TextColumn::make('user.id')->label(__('User ID')),
+                TextColumn::make('lockable.id')->label(__('Lockable ID')),
+                TextColumn::make('lockable_type')->label(__('Lockable type')),
+                TextColumn::make('created_at')->label(__('Created at')),
+                TextColumn::make('updated_at')->label(__('Updated at')),
+                TextColumn::make('updated_at')->label(__('Expired'))
                     ->badge()
                     ->color(static function ($record): string {
                         if ($record->isExpired()) {

--- a/src/Resources/ResourceLockResource.php
+++ b/src/Resources/ResourceLockResource.php
@@ -17,7 +17,7 @@ class ResourceLockResource extends Resource
 
     public static function getModel(): string
     {
-        return __(config('resource-lock.models.ResourceLock', ResourceLock::class));
+        return config('resource-lock.models.ResourceLock', ResourceLock::class);
     }
 
     public static function getPluralLabel(): string


### PR DESCRIPTION
I enabled translation for all columns and additionally introduced the 'getPluralLabel' function, along with a new configuration key, enabling the customization of resource page names.