### PR TITLE
Fix empty white space caused from modal with inline-block

### DIFF
--- a/resources/views/components/resource-lock-observer.blade.php
+++ b/resources/views/components/resource-lock-observer.blade.php
@@ -17,10 +17,11 @@
     </script>
 
     <x-filament::modal
-            id="resourceIsLockedNotice"
-            :closeButton="false"
-            :disabled="true"
-            :closeByClickingAway="false"
+        id="resourceIsLockedNotice"
+        displayClasses="block"
+        :closeButton="false"
+        :disabled="true"
+        :closeByClickingAway="false"
     >
         <div x-data="{ resourceLockOwner: null}"  @open-modal.window="(event) => { resourceLockOwner = event.detail.resourceLockOwner}">
             <div class="flex justify-center ">


### PR DESCRIPTION
Causes an issue with the `h-screen` used in Filament's nav

<img width="1134" alt="Screenshot 2023-09-18 at 12 20 18" src="https://github.com/kenepa/resource-lock/assets/533658/4bcfe8ab-452b-42f9-9c9c-e7776737751b">
