### PR TITLE
Renamed ResourceLockResource to LockResource.

### DIFF
--- a/config/resource-lock.php
+++ b/config/resource-lock.php
@@ -28,7 +28,7 @@ return [
     |
     */
     'resource' => [
-        'class' => \Kenepa\ResourceLock\Resources\ResourceLockResource::class,
+        'class' => \Kenepa\ResourceLock\Resources\LockResource::class,
     ],
 
     /*

--- a/src/ResourceLockPlugin.php
+++ b/src/ResourceLockPlugin.php
@@ -6,7 +6,7 @@ use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Support\Facades\FilamentView;
 use Illuminate\Support\Facades\Blade;
-use Kenepa\ResourceLock\Resources\ResourceLockResource;
+use Kenepa\ResourceLock\Resources\LockResource;
 use Livewire\Livewire;
 
 class ResourceLockPlugin implements Plugin
@@ -25,7 +25,7 @@ class ResourceLockPlugin implements Plugin
     {
         $panel
             ->resources([
-                config('resource-lock.resource.class', ResourceLockResource::class),
+                config('resource-lock.resource.class', LockResource::class),
             ]);
     }
 

--- a/src/Resources/LockResource.php
+++ b/src/Resources/LockResource.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Gate;
 use Kenepa\ResourceLock\Models\ResourceLock;
 use Kenepa\ResourceLock\Resources\ResourceLockResource\ManageResourceLocks;
 
-class ResourceLockResource extends Resource
+class LockResource extends Resource
 {
     public static function getNavigationIcon(): ?string
     {

--- a/src/Resources/ResourceLockResource/ManageResourceLocks.php
+++ b/src/Resources/ResourceLockResource/ManageResourceLocks.php
@@ -5,11 +5,11 @@ namespace Kenepa\ResourceLock\Resources\ResourceLockResource;
 use Filament\Pages\Actions\Action;
 use Filament\Resources\Pages\ManageRecords;
 use Kenepa\ResourceLock\Models\ResourceLock;
-use Kenepa\ResourceLock\Resources\ResourceLockResource;
+use Kenepa\ResourceLock\Resources\LockResource;
 
 class ManageResourceLocks extends ManageRecords
 {
-    protected static string $resource = ResourceLockResource::class;
+    protected static string $resource = LockResource::class;
 
     protected function getActions(): array
     {


### PR DESCRIPTION
Due to issues with Filament shield renamed the resource.
Fixes: #13 & #5 

All the credit goes to [@eelco](https://github.com/eelco2k) for figuring this out.