### PR TITLE
Expired resource locks disable locking functionality

### DIFF
--- a/src/Models/Concerns/HasLocks.php
+++ b/src/Models/Concerns/HasLocks.php
@@ -17,7 +17,7 @@ trait HasLocks
      */
     public function resourceLock(): MorphOne
     {
-        return $this->morphOne(ResourceLockPlugin::get()->getResourceLockModel(), 'lockable');
+        return $this->morphOne(ResourceLockPlugin::get()->getResourceLockModel(), 'lockable')->latestOfMany();
     }
 
     /**

--- a/tests/Unit/modelHasLockTest.php
+++ b/tests/Unit/modelHasLockTest.php
@@ -184,3 +184,31 @@ it('prevents locking a resource that is already locked by another user', functio
     expect($post->isLockedByCurrentUser())->toBeFalse();
     assertDatabaseCount(ResourceLock::class, 1);
 });
+
+it('prevents multiple users from locking when expired locks exist', function () {
+    // Arrange
+    $user1 = createUser();
+    $user2 = createUser();
+    $post = createPost();
+
+    // Create multiple expired locks for the same resource
+    createExpiredResourceLock($user1, $post);
+    createExpiredResourceLock($user2, $post);
+
+    // Act & Assert with user1
+    actingAs($user1);
+    $post->refresh();
+    expect($post->isUnlocked())
+        ->toBeTrue()
+        ->and($post->lock())
+        ->toBeTrue(); // This should be true because locks are expired
+    // User1 can lock because resource appears unlocked
+
+    // Act & Assert with user2
+    actingAs($user2);
+    $post->refresh();
+    expect($post->isUnlocked())
+        ->toBeFalse()
+        ->and($post->lock())
+        ->toBeFalse();
+});


### PR DESCRIPTION
When there are expired locks for the resource, all users are allowed to edit it. This happens because the check is performed with the first available lock and not with the latest.

This pull request fixes the issue.