### PR TITLE
feat: add support for Filament v5 and Livewire v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,18 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "filament/filament": "^4.0",
+        "filament/filament": "^5.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.0|^8.1",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
         "pestphp/pest": "^2.0|^3.7",
         "pestphp/pest-plugin-laravel": "^2.0|^3.1",
-        "pestphp/pest-plugin-livewire": "^2.0|^3.0",
+        "pestphp/pest-plugin-livewire": "^3.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
         "phpstan/phpstan-phpunit": "^1.0|^2.0",

--- a/src/ResourceLockPlugin.php
+++ b/src/ResourceLockPlugin.php
@@ -89,7 +89,7 @@ class ResourceLockPlugin implements Plugin
 
         FilamentView::registerRenderHook(
             PanelsRenderHook::PAGE_START,
-            fn (): string => Blade::render('@livewire(\'resource-lock-observer\')'),
+            fn (): string => Blade::render('<livewire:resource-lock-observer />'),
         );
     }
 

--- a/src/Resources/Pages/Concerns/UsesLocks.php
+++ b/src/Resources/Pages/Concerns/UsesLocks.php
@@ -2,6 +2,8 @@
 
 namespace Kenepa\ResourceLock\Resources\Pages\Concerns;
 
+use Livewire\Attributes\On;
+
 /**
  * This trait provides common methods used by both UsesResourceLock and
  * UsesSimpleResourceLock traits, offering core functionality for managing
@@ -81,6 +83,7 @@ trait UsesLocks
         $this->dispatch('disablePollingInResourceLockObserver');
     }
 
+    #[On('resourceLockObserver::renewLock')]
     public function renewLock()
     {
         $record = $this->record ?? $this->resourceRecord;

--- a/src/Resources/Pages/Concerns/UsesResourceLock.php
+++ b/src/Resources/Pages/Concerns/UsesResourceLock.php
@@ -3,6 +3,7 @@
 namespace Kenepa\ResourceLock\Resources\Pages\Concerns;
 
 use Kenepa\ResourceLock\ResourceLockPlugin;
+use Livewire\Attributes\On;
 
 /*
  * The Resource Lock Trait provides several functions to an Edit Resource page to lock & unlock resources.
@@ -20,25 +21,13 @@ trait UsesResourceLock
     private bool $isLockable = true;
 
     /*
-     * Initializes livewire event listeners on boot. This function uses livewire lifecycle hooks
-     * to hook into lifecycle events of the livewire component that uses this trait
-     * learn more: https://laravel-livewire.com/docs/2.x/traits
-     */
-    public function bootUsesResourceLock(): void
-    {
-        $this->listeners = array_merge($this->listeners, [
-            'resourceLockObserver::init' => 'resourceLockObserverInit',
-            'resourceLockObserver::unload' => 'resourceLockObserverUnload',
-            'resourceLockObserver::unlock' => 'resourceLockObserverUnlock',
-            'resourceLockObserver::renewLock' => 'renewLock',
-        ]);
-    }
-
-    /*
      * This function is triggered when the resource lock observer component has been loaded.
      * The resource lock observer is a livewire component that triggers function based
      * on certain states and events that are happening on the page.
+     *
+     * Uses Livewire v4 #[On] attribute for event listening (replaces $this->listeners array).
      */
+    #[On('resourceLockObserver::init')]
     public function resourceLockObserverInit()
     {
         $this->returnUrl = $this->getResource()::getUrl('index');
@@ -46,6 +35,7 @@ trait UsesResourceLock
         $this->setupPolling();
     }
 
+    #[On('resourceLockObserver::unload')]
     public function resourceLockObserverUnload()
     {
         $this->record->unlock();
@@ -56,6 +46,7 @@ trait UsesResourceLock
      * presented to the users. This action is seen as forced unlock and will replace any lock
      * That is currently in place for that specific resource. Hone this power with care.
      */
+    #[On('resourceLockObserver::unlock')]
     public function resourceLockObserverUnlock()
     {
         if ($this->record->unlock(force: true)) {

--- a/src/Resources/Pages/Concerns/UsesSimpleResourceLock.php
+++ b/src/Resources/Pages/Concerns/UsesSimpleResourceLock.php
@@ -3,6 +3,7 @@
 namespace Kenepa\ResourceLock\Resources\Pages\Concerns;
 
 use Kenepa\ResourceLock\ResourceLockPlugin;
+use Livewire\Attributes\On;
 
 trait UsesSimpleResourceLock
 {
@@ -15,16 +16,6 @@ trait UsesSimpleResourceLock
     public string $resourceLockType;
 
     private bool $isLockable = true;
-
-    public function bootUsesSimpleResourceLock(): void
-    {
-        $this->listeners = array_merge($this->listeners, [
-            'resourceLockObserver::init' => 'resourceLockObserverInit',
-            'resourceLockObserver::unload' => 'resourceLockObserverUnload',
-            'resourceLockObserver::unlock' => 'resourceLockObserverUnlock',
-            'resourceLockObserver::renewLock' => 'renewLock',
-        ]);
-    }
 
     public function mountTableAction(string $name, ?string $record = null, array $arguments = []): mixed
     {
@@ -54,12 +45,14 @@ trait UsesSimpleResourceLock
         return null;
     }
 
+    #[On('resourceLockObserver::unload')]
     public function resourceLockObserverUnload()
     {
         $this->resourceRecord->unlock();
         $this->disablePolling();
     }
 
+    #[On('resourceLockObserver::unlock')]
     public function resourceLockObserverUnlock()
     {
         if ($this->resourceRecord->unlock(force: true)) {


### PR DESCRIPTION
## Summary

This PR adds support for **Filament v5** and **Livewire v4**.

### Changes

#### \composer.json\
- Bumped \ilament/filament\ dependency from \^4.0\ to \^5.0\
- Added \^13.0\ to \illuminate/contracts\ version constraint
- Removed \orchestra/testbench ^7.0\ (incompatible with Filament v5 / Laravel 11+)
- Dropped \pestphp/pest-plugin-livewire ^2.0\ (Livewire v4 requires \^3.0\)

#### Event listeners: \\->listeners\ → \#[On]\ attributes
Livewire v4 deprecates the \\->listeners\ array in favor of the \#[On]\ PHP attribute. The old approach still works but is not recommended.

- **\UsesResourceLock\**: removed \ootUsesResourceLock()\ boot method, added \#[On('resourceLockObserver::init')]\, \#[On('resourceLockObserver::unload')]\ and \#[On('resourceLockObserver::unlock')]\ attributes to the corresponding handler methods
- **\UsesSimpleResourceLock\**: removed \ootUsesSimpleResourceLock()\ boot method, added \#[On('resourceLockObserver::unload')]\ and \#[On('resourceLockObserver::unlock')]\ attributes
- **\UsesLocks\**: added \#[On('resourceLockObserver::renewLock')]\ attribute to \enewLock()\

#### Blade component rendering
Livewire v4 requires component tags to be properly closed. Replaced the deprecated \@livewire()\ Blade directive with a self-closing component tag:

\\\php
// Before
Blade::render('@livewire(\'resource-lock-observer\')')

// After
Blade::render('<livewire:resource-lock-observer />')
\\\

### Compatibility

| Package | Version |
|---|---|
| PHP | ^8.2 |
| Laravel | ^11.28 |
| Filament | ^5.0 |
| Livewire | ^4.0 (pulled in by Filament v5) |